### PR TITLE
Only log if LOG_ENABLE approves logging

### DIFF
--- a/mqtt2notifysend.sh
+++ b/mqtt2notifysend.sh
@@ -21,8 +21,10 @@ LOG_ENABLE={$LOG_ENABLE:="true"}
 log_counter=0
 
 function log() {
-    # TODO print if LOG_ENABLE enabled
-    echo "[#$log_counter] $1"
+    if [[ "${LOG_ENABLE}" == "true" || "${LOG_ENABLE}" == "1" ]]
+    then
+        echo "[#$log_counter] $1"
+    fi
 }
 
 while true


### PR DESCRIPTION
Checks for `"true"` and `"1"` values, so it allows users to use the common abbrevation `LOG_ENABLE=1` or `LOG_ENABLE=0` instead of `LOG_ENABLE=true` or `LOG_ENABLE=false`.

As I want to use your script for my own system, I thought about doing one of your todos.